### PR TITLE
Change of getting of config

### DIFF
--- a/src/main/java/de/bananaco/report/Config.java
+++ b/src/main/java/de/bananaco/report/Config.java
@@ -17,8 +17,7 @@ public class Config {
     private ReportPlugin rp;
     
     public Config(ReportPlugin rp) {
-        this.file = new File("plugins/bReport/config.yml");
-        this.config = new YamlConfiguration();
+        this.file = rp.getConfig();
         this.levenshtein = 6;
         this.ticketDisplay = 7;
         this.reportLength = 3;


### PR DESCRIPTION
Gets the config more efficiently rather then getting the file.
Also if you want more flexibility about what the file name is you could do: 
new File(rp.getDataFolder()+File.seperator+"config.yml");
At least then you don't hardcode the route of the plugin.
